### PR TITLE
Provide correct classes to admin notice and make dismissable

### DIFF
--- a/showallthehooks.php
+++ b/showallthehooks.php
@@ -140,6 +140,6 @@ function _showallthehooks_wp_show_notices($args) {
     $message = '<ul><li>' . implode('</li><li>', $messages) . '</li></ul>';
   }
   print <<<EOT
-    <div class="info notice">{$message}</div>
+    <div class="notice notice-info is-dismissible">{$message}</div>
 EOT;
 }


### PR DESCRIPTION
Just a simple thing really - makes the admin notice properly styled and also provides an "x" in the top right that can be clicked on to dismiss the list of hooks.